### PR TITLE
Redirect errors to standard error (stderr)

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -87,7 +87,7 @@ SQLFMT_ADDR=":8080" %[1]s
 	}
 
 	if err := runCmd(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This PR ensures that error messages are sent to the standard error stream (stderr) instead of standard output (stdout), making it easier to distinguish errors from regular output.

#### Changes

- Updated error handling to output messages to stderr.

#### Rationale

Redirecting to stderr aligns with best practices for error handling and improves clarity in error logging.

Let me know if there are any changes needed. Thank you!

Thank you for maintaining this tool—I rely on it regularly, and it’s been incredibly helpful!